### PR TITLE
Disable auth

### DIFF
--- a/docker/shiro.ini
+++ b/docker/shiro.ini
@@ -36,7 +36,7 @@ ssl.enabled = false
 #/*/update/** = authcBasic,user[admin]
 #/*/data/** = authcBasic,user[admin]
 
-## Comment out to disable basic auth
+## Comment out to enable basic auth
 /$/** = anon
 
 # Everything else (static files, ect)

--- a/docker/shiro.ini
+++ b/docker/shiro.ini
@@ -17,44 +17,27 @@
 # Development
 ssl.enabled = false
 
-plainMatcher=org.apache.shiro.authc.credential.SimpleCredentialsMatcher
-#iniRealm=org.apache.shiro.realm.text.IniRealm
-iniRealm.credentialsMatcher = $plainMatcher
-
-#localhost=org.apache.jena.fuseki.authz.LocalhostFilter
+## Uncomment to enable basic auth
+# plainMatcher=org.apache.shiro.authc.credential.SimpleCredentialsMatcher
+# iniRealm.credentialsMatcher = $plainMatcher
 
 [users]
-# Implicitly adds "iniRealm =  org.apache.shiro.realm.text.IniRealm"
-# The admin password will be replaced by value of ADMIN_PASSWORD
-# variable by docker-entrypoint.sh on FIRST start up.
-admin=${ADMIN_PASSWORD}
+## Uncomment to enable basic auth
+# admin=${ADMIN_PASSWORD}
 
 [roles]
 
 [urls]
-## Control functions open to anyone
-/$/status = anon
-/$/ping   = anon
 
-## and the rest are restricted
-/$/** = authcBasic,user[admin]
+## Uncomment to enable basic auth
+#/$/status = anon
+#/$/ping   = anon
+#/$/** = authcBasic,user[admin]
+#/*/update/** = authcBasic,user[admin]
+#/*/data/** = authcBasic,user[admin]
 
-## Sparql update is restricted
-/*/update/** = authcBasic,user[admin]
+## Comment out to disable basic auth
+/$/** = anon
 
-## GSP update is restricted
-/*/data/** = authcBasic,user[admin]
-
-
-## If you want simple, basic authentication user/password
-## on the operations,
-##    1 - set a password in [users]
-##    2 - change the line above to:
-## /$/** = authcBasic,user[admin]
-## and set a better
-
-## or to allow any access.
-##/$/** = anon
-
-# Everything else
+# Everything else (static files, ect)
 /**=anon


### PR DESCRIPTION
In GLACIATION, we do not invest time into authentication because there is no need in our sandboxed environments. May be we will add OAuth capabilities later.

At the moment I disable any auth to avoid password management for us and for partners.